### PR TITLE
build: nom 8.0 and MSRV 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nom-rule"
 version = "0.4.0"
-authors = ["andylokandy"]
 edition = "2021"
+rust-version = "1.80.0"
 license = "MIT"
 description = "A procedural macro for writing nom parsers using a grammar-like DSL."
 homepage = "https://github.com/andylokandy/nom-rule"
@@ -14,12 +14,12 @@ keywords = ["nom", "parser", "grammar", "DSL", "parsing"]
 proc-macro = true
 
 [dependencies]
-nom = "7"
-pratt = "0.4"
-proc-macro-error2 = "2.0.1"
+nom = { version = "8" }
+pratt = { version = "0.4" }
+proc-macro-error2 = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = "1"
-syn = "2"
+quote = { version = "1" }
+syn = { version = "2" }
 
 [dev-dependencies]
-logos = "0.14"
+logos = { version = "0.15" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 andylokandy
+Copyright 2022-2025 andylokandy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -34,32 +34,34 @@ fn ident<'a>(input: Input<'a>) -> IResult<Input<'a>, &str> {
     // Implementation
 }
 
-// Use the `rule!` macro
-let mut parser = rule!(
-    CREATE ~ TABLE ~ #ident ~ ^"(" ~ (#ident ~ #ident ~ ","?)* ~ ")" ~ ";"
-    : "CREATE TABLE statement"
-);
+fn main() {
+    // Use the `rule!` macro
+    let mut parser = rule!(
+        CREATE ~ TABLE ~ #ident ~ ^"(" ~ (#ident ~ #ident ~ ","?)* ~ ")" ~ ";"
+        : "CREATE TABLE statement"
+    );
+}
 ```
 
 ## Syntax
 
 The `rule!` macro follows these rules:
 
-| **Syntax**            | **Description**                                                                  | **Expanded to**                         | **Operator Precedence**  |
-|-----------------------|----------------------------------------------------------------------------------|-----------------------------------------|--------------------------|
-| `TOKEN`               | Matches a token by kind.                                                         | `match_token(TOKEN)`                    | -                        |
-| `"("`                 | Matches a token by its text.                                                     | `match_text("(")`                       | -                        |
-| `#fn_name`            | Calls an external nom parser function `fn_name`.                                 | `fn_name`                               | -                        |
-| `#fn_name(a, b, c)`   | Calls an external nom parser function `fn_name` with arguments.                  | `fn_name(a, b, c)`                      | -                        |
-| `a ~ b ~ c`           | Sequences parsers `a`, `b`, and `c`.                                             | `nom::sequence::tuple((a, b, c))`       | 3 (Left Associative)     |
-| `a+`                  | One or more repetitions.                                                         | `nom::multi::many1(a)`                  | 4 (Postfix)              |
-| `a*`                  | Zero or more repetitions.                                                        | `nom::multi::many0(a)`                  | 4 (Postfix)              |
-| `a?`                  | Optional parser.                                                                 | `nom::combinator::opt(a)`               | 4 (Postfix)              |
-| `a \| b \| c`         | Choice between parsers `a`, `b`, and `c`.                                        | `nom::branch::alt((a, b, c))`           | 1 (Left Associative)     |
-| `&a`                  | Peeks at parser `a` without consuming input.                                     | `nom::combinator::peek(a)`              | 5 (Prefix)               |
-| `!a`                  | Negative lookahead for parser `a`.                                               | `nom::combinator::not(a)`               | 5 (Prefix)               |
-| `^a`                  | Cuts the parser `a`.                                                             | `nom::combinator::cut(a)`               | 5 (Prefix)               |
-| `... : "description"` | Adds a context description for error reporting.                                  | `nom::error::context("description", a)` | 2 (Postfix)              |
+| **Syntax**            | **Description**                                                 | **Expanded to**                         | **Operator Precedence** |
+|-----------------------|-----------------------------------------------------------------|-----------------------------------------|-------------------------|
+| `TOKEN`               | Matches a token by kind.                                        | `match_token(TOKEN)`                    | -                       |
+| `"("`                 | Matches a token by its text.                                    | `match_text("(")`                       | -                       |
+| `#fn_name`            | Calls an external nom parser function `fn_name`.                | `fn_name`                               | -                       |
+| `#fn_name(a, b, c)`   | Calls an external nom parser function `fn_name` with arguments. | `fn_name(a, b, c)`                      | -                       |
+| `a ~ b ~ c`           | Sequences parsers `a`, `b`, and `c`.                            | `nom::sequence::tuple((a, b, c))`       | 3 (Left Associative)    |
+| `a+`                  | One or more repetitions.                                        | `nom::multi::many1(a)`                  | 4 (Postfix)             |
+| `a*`                  | Zero or more repetitions.                                       | `nom::multi::many0(a)`                  | 4 (Postfix)             |
+| `a?`                  | Optional parser.                                                | `nom::combinator::opt(a)`               | 4 (Postfix)             |
+| `a \| b \| c`         | Choice between parsers `a`, `b`, and `c`.                       | `nom::branch::alt((a, b, c))`           | 1 (Left Associative)    |
+| `&a`                  | Peeks at parser `a` without consuming input.                    | `nom::combinator::peek(a)`              | 5 (Prefix)              |
+| `!a`                  | Negative lookahead for parser `a`.                              | `nom::combinator::not(a)`               | 5 (Prefix)              |
+| `^a`                  | Cuts the parser `a`.                                            | `nom::combinator::cut(a)`               | 5 (Prefix)              |
+| `... : "description"` | Adds a context description for error reporting.                 | `nom::error::context("description", a)` | 2 (Postfix)             |
 
 ## Example
 

--- a/examples/sqlparser.rs
+++ b/examples/sqlparser.rs
@@ -2,8 +2,11 @@ use logos::Logos;
 use nom::combinator::map;
 use nom::error::ErrorKind;
 use nom::error::ParseError;
-use nom::IResult;
+use nom::Parser;
+use nom::{IResult, Needed};
 use nom_rule::rule;
+use std::iter::{Cloned, Enumerate};
+use std::slice::Iter;
 use TokenKind::*;
 
 #[derive(Logos, Clone, Copy, Debug, PartialEq)]
@@ -33,7 +36,54 @@ struct Token<'a> {
     span: std::ops::Range<usize>,
 }
 
-type Input<'a> = &'a [Token<'a>];
+#[derive(Debug, Clone)]
+struct Input<'a>(&'a [Token<'a>]);
+
+impl<'a> nom::Input for Input<'a> {
+    type Item = Token<'a>;
+    type Iter = Cloned<Iter<'a, Token<'a>>>;
+    type IterIndices = Enumerate<Self::Iter>;
+
+    fn input_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn take(&self, index: usize) -> Self {
+        Input(&self.0[0..index])
+    }
+
+    fn take_from(&self, index: usize) -> Self {
+        Input(&self.0[index..])
+    }
+
+    fn take_split(&self, index: usize) -> (Self, Self) {
+        let (prefix, suffix) = self.0.split_at(index);
+        (Input(suffix), Input(prefix))
+    }
+
+    fn position<P>(&self, predicate: P) -> Option<usize>
+    where
+        P: Fn(Self::Item) -> bool,
+    {
+        self.0.iter().position(|b| predicate(b.clone()))
+    }
+
+    fn iter_elements(&self) -> Self::Iter {
+        self.0.iter().cloned()
+    }
+
+    fn iter_indices(&self) -> Self::IterIndices {
+        self.iter_elements().enumerate()
+    }
+
+    fn slice_index(&self, count: usize) -> Result<usize, Needed> {
+        if self.0.len() >= count {
+            Ok(count)
+        } else {
+            Err(Needed::new(count - self.0.len()))
+        }
+    }
+}
 
 fn tokenise(input: &str) -> Vec<Token> {
     let mut lex = TokenKind::lexer(input);
@@ -62,10 +112,8 @@ fn match_token<'a, Error: ParseError<Input<'a>>>(
     move |i| satisfy(|token: &Token<'a>| token.kind == kind)(i)
 }
 
-fn ident<'a, Error: ParseError<Input<'a>>>(i: Input<'a>) -> IResult<Input<'a>, &str, Error> {
-    map(satisfy(|token| token.kind == TokenKind::Ident), |token| {
-        token.text
-    })(i)
+fn ident<'a, Error: ParseError<Input<'a>>>(i: Input<'a>) -> IResult<Input<'a>, &'a str, Error> {
+    map(satisfy(|token| token.kind == Ident), |token| token.text).parse(i)
 }
 
 fn satisfy<'a, F, Error: ParseError<Input<'a>>>(
@@ -74,11 +122,11 @@ fn satisfy<'a, F, Error: ParseError<Input<'a>>>(
 where
     F: Fn(&Token<'a>) -> bool,
 {
-    move |i| match i.get(0).map(|t| {
+    move |i| match i.0.get(0).map(|t| {
         let b = cond(&t);
         (t, b)
     }) {
-        Some((t, true)) => Ok((&i[1..], t)),
+        Some((t, true)) => Ok((Input(&i.0[1..]), t)),
         _ => Err(nom::Err::Error(Error::from_error_kind(
             i,
             ErrorKind::Satisfy,
@@ -87,7 +135,7 @@ where
 }
 
 #[derive(Debug)]
-#[allow(de)]
+#[allow(dead_code)]
 struct CreateTableStmt {
     name: String,
     columns: Vec<(String, String)>,
@@ -110,9 +158,18 @@ fn main() {
         },
     );
 
-    let res: IResult<Input, CreateTableStmt> = create_table(&tokens);
+    let result: IResult<Input, CreateTableStmt> = create_table.parse(Input(&tokens));
+    let (rest, stmt) = result.unwrap();
+
+    println!("{stmt:?}");
+
+    assert!(rest.0.is_empty());
+    assert_eq!(stmt.name, "users");
     assert_eq!(
-        format!("{res:?}"),
-        r#"Ok(([], CreateTableStmt { name: "users", columns: [("id", "INT"), ("name", "VARCHAR")] }))"#
+        &stmt.columns,
+        &[
+            ("id".to_string(), "INT".to_string()),
+            ("name".to_string(), "VARCHAR".to_string())
+        ]
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! | `"@"`                 | Matches a token by its text.                                                     | `match_text("@")`                       | -                        |
 //! | `#fn_name`            | Calls an external nom parser function `fn_name`.                                 | `fn_name`                               | -                        |
 //! | `#fn_name(a, b, c)`   | Calls an external nom parser function `fn_name` with arguments.                  | `fn_name(a, b, c)`                      | -                        |
-//! | `a ~ b ~ c`           | Sequences parsers `a`, `b`, and `c`.                                             | `nom::sequence::tuple((a, b, c))`       | 3 (Left Associative)     |
+//! | `a ~ b ~ c`           | Sequences parsers `a`, `b`, and `c`.                                             | `((a, b, c))`                           | 3 (Left Associative)     |
 //! | `a+`                  | One or more repetitions.                                                         | `nom::multi::many1(a)`                  | 4 (Postfix)              |
 //! | `a*`                  | Zero or more repetitions.                                                        | `nom::multi::many0(a)`                  | 4 (Postfix)              |
 //! | `a?`                  | Optional parser.                                                                 | `nom::combinator::opt(a)`               | 4 (Postfix)              |
@@ -657,7 +657,7 @@ impl Rule {
                     .iter()
                     .map(|rule| rule.to_token_stream(terminal))
                     .collect();
-                quote! { nom::sequence::tuple((#list)) }
+                quote! { ((#list)) }
             }
             Rule::Choice(_, rules) => {
                 let list: Punctuated<TokenStream, Token![,]> = rules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! | **Syntax**            | **Description**                                                                  | **Expanded to**                         | **Operator Precedence**  |
 //! |-----------------------|----------------------------------------------------------------------------------|-----------------------------------------|--------------------------|
 //! | `TOKEN`               | Matches a token by kind.                                                         | `match_token(TOKEN)`                    | -                        |
-//! | `"("`                 | Matches a token by its text.                                                     | `match_text("(")`                       | -                        |
+//! | `"@"`                 | Matches a token by its text.                                                     | `match_text("@")`                       | -                        |
 //! | `#fn_name`            | Calls an external nom parser function `fn_name`.                                 | `fn_name`                               | -                        |
 //! | `#fn_name(a, b, c)`   | Calls an external nom parser function `fn_name` with arguments.                  | `fn_name(a, b, c)`                      | -                        |
 //! | `a ~ b ~ c`           | Sequences parsers `a`, `b`, and `c`.                                             | `nom::sequence::tuple((a, b, c))`       | 3 (Left Associative)     |
@@ -54,8 +54,8 @@ use nom::combinator::opt;
 use nom::error::make_error;
 use nom::error::ErrorKind;
 use nom::multi::many0;
-use nom::sequence::tuple;
 use nom::IResult;
+use nom::Parser;
 use pratt::Affix;
 use pratt::Associativity;
 use pratt::PrattError;
@@ -89,7 +89,7 @@ pub fn rule(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     // Attempt to parse the paths for match_text and match_token
     let (i, terminals) = if let Ok((rest, (match_text, _, match_token, _))) =
-        tuple((path, match_punct(','), path, match_punct(',')))(&i)
+        (path, match_punct(','), path, match_punct(',')).parse(&i)
     {
         (
             rest,
@@ -185,7 +185,7 @@ fn match_punct<'a>(punct: char) -> impl FnMut(Input<'a>) -> IResult<Input<'a>, T
     }
 }
 
-fn group<'a>(i: Input<'a>) -> IResult<Input<'a>, Group> {
+fn group(i: Input) -> IResult<Input, Group> {
     match i.get(0).and_then(|token| match token {
         TokenTree::Group(group) => Some(group.clone()),
         _ => None,
@@ -195,7 +195,7 @@ fn group<'a>(i: Input<'a>) -> IResult<Input<'a>, Group> {
     }
 }
 
-fn literal<'a>(i: Input<'a>) -> IResult<Input<'a>, Literal> {
+fn literal(i: Input) -> IResult<Input, Literal> {
     match i.get(0).and_then(|token| match token {
         TokenTree::Literal(lit) => Some(lit.clone()),
         _ => None,
@@ -205,7 +205,7 @@ fn literal<'a>(i: Input<'a>) -> IResult<Input<'a>, Literal> {
     }
 }
 
-fn ident<'a>(i: Input<'a>) -> IResult<Input<'a>, Ident> {
+fn ident(i: Input) -> IResult<Input, Ident> {
     match i.get(0).and_then(|token| match token {
         TokenTree::Ident(ident) => Some(ident.clone()),
         _ => None,
@@ -215,12 +215,9 @@ fn ident<'a>(i: Input<'a>) -> IResult<Input<'a>, Ident> {
     }
 }
 
-fn path<'a>(i: Input<'a>) -> IResult<Input<'a>, (Span, Path)> {
+fn path(i: Input) -> IResult<Input, (Span, Path)> {
     map(
-        tuple((
-            ident,
-            many0(tuple((match_punct(':'), match_punct(':'), ident))),
-        )),
+        (ident, many0((match_punct(':'), match_punct(':'), ident))),
         |(head, tail)| {
             let mut segments = vec![head.clone()];
             segments.extend(tail.into_iter().map(|(_, _, segment)| segment));
@@ -230,13 +227,14 @@ fn path<'a>(i: Input<'a>) -> IResult<Input<'a>, (Span, Path)> {
                 .unwrap_or(Span::call_site());
             (span, Path { segments })
         },
-    )(i)
+    )
+    .parse(i)
 }
 
 fn parse_rule(tokens: TokenStream) -> Rule {
     let i: Vec<TokenTree> = tokens.into_iter().collect();
 
-    let (i, elems) = many0(parse_rule_element)(&i).unwrap();
+    let (i, elems) = many0(parse_rule_element).parse(&i).unwrap();
     if !i.is_empty() {
         let rest: TokenStream = i.iter().cloned().collect();
         abort!(rest, "unable to parse the following rules: {}", rest);
@@ -256,11 +254,11 @@ fn parse_rule(tokens: TokenStream) -> Rule {
     rule
 }
 
-fn parse_rule_element<'a>(i: Input<'a>) -> IResult<Input<'a>, WithSpan> {
+fn parse_rule_element(i: Input) -> IResult<Input, WithSpan> {
     let function_call = |i| {
         let (i, hashtag) = match_punct('#')(i)?;
         let (i, (path_span, fn_path)) = path(i)?;
-        let (i, args) = opt(group)(i)?;
+        let (i, args) = opt(group).parse(i)?;
         let span = hashtag.span().join(path_span).unwrap_or(Span::call_site());
         let span = args
             .as_ref()
@@ -275,7 +273,7 @@ fn parse_rule_element<'a>(i: Input<'a>) -> IResult<Input<'a>, WithSpan> {
             },
         ))
     };
-    let context = map(tuple((match_punct(':'), literal)), |(colon, msg)| {
+    let context = map((match_punct(':'), literal), |(colon, msg)| {
         let span = colon.span().join(msg.span()).unwrap_or(Span::call_site());
         WithSpan {
             elem: RuleElement::Context(msg),
@@ -329,7 +327,8 @@ fn parse_rule_element<'a>(i: Input<'a>) -> IResult<Input<'a>, WithSpan> {
         }),
         function_call,
         context,
-    ))(i)
+    ))
+    .parse(i)
 }
 
 fn unwrap_pratt(res: Result<Rule, PrattError<WithSpan, pratt::NoError>>) -> Rule {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,8 @@ use nom::combinator::opt;
 use nom::error::make_error;
 use nom::error::ErrorKind;
 use nom::multi::many0;
-use nom::IResult;
 use nom::Parser;
+use nom::{IResult, Needed};
 use pratt::Affix;
 use pratt::Associativity;
 use pratt::PrattError;
@@ -75,6 +75,9 @@ use proc_macro_error2::proc_macro_error;
 use quote::quote;
 use quote::ToTokens;
 use quote::TokenStreamExt;
+use std::iter::{Cloned, Enumerate};
+use std::ops::Deref;
+use std::slice::Iter;
 use syn::punctuated::Punctuated;
 use syn::Token;
 
@@ -89,7 +92,7 @@ pub fn rule(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     // Attempt to parse the paths for match_text and match_token
     let (i, terminals) = if let Ok((rest, (match_text, _, match_token, _))) =
-        (path, match_punct(','), path, match_punct(',')).parse(&i)
+        (path, match_punct(','), path, match_punct(',')).parse(Input(&i))
     {
         (
             rest,
@@ -99,7 +102,7 @@ pub fn rule(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }),
         )
     } else {
-        (i.as_slice(), None)
+        (Input(i.as_slice()), None)
     };
 
     let terminal = terminals.unwrap_or_else(|| CustomTerminal {
@@ -173,14 +176,69 @@ struct CustomTerminal {
     match_token: Path,
 }
 
-type Input<'a> = &'a [TokenTree];
+#[derive(Debug, Clone)]
+struct Input<'a>(&'a [TokenTree]);
+
+impl Deref for Input<'_> {
+    type Target = [TokenTree];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a> nom::Input for Input<'a> {
+    type Item = TokenTree;
+    type Iter = Cloned<Iter<'a, TokenTree>>;
+    type IterIndices = Enumerate<Self::Iter>;
+
+    fn input_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn take(&self, index: usize) -> Self {
+        Input(&self.0[0..index])
+    }
+
+    fn take_from(&self, index: usize) -> Self {
+        Input(&self.0[index..])
+    }
+
+    fn take_split(&self, index: usize) -> (Self, Self) {
+        let (prefix, suffix) = self.0.split_at(index);
+        (Input(suffix), Input(prefix))
+    }
+
+    fn position<P>(&self, predicate: P) -> Option<usize>
+    where
+        P: Fn(Self::Item) -> bool,
+    {
+        self.iter().position(|b| predicate(b.clone()))
+    }
+
+    fn iter_elements(&self) -> Self::Iter {
+        self.0.iter().cloned()
+    }
+
+    fn iter_indices(&self) -> Self::IterIndices {
+        self.iter_elements().enumerate()
+    }
+
+    fn slice_index(&self, count: usize) -> Result<usize, Needed> {
+        if self.len() >= count {
+            Ok(count)
+        } else {
+            Err(Needed::new(count - self.len()))
+        }
+    }
+}
 
 fn match_punct<'a>(punct: char) -> impl FnMut(Input<'a>) -> IResult<Input<'a>, TokenTree> {
     move |i| match i.get(0).and_then(|token| match token {
         TokenTree::Punct(p) if p.as_char() == punct => Some(token.clone()),
         _ => None,
     }) {
-        Some(token) => Ok((&i[1..], token)),
+        Some(token) => Ok((Input(&i.0[1..]), token)),
         _ => Err(nom::Err::Error(make_error(i, ErrorKind::Satisfy))),
     }
 }
@@ -190,7 +248,7 @@ fn group(i: Input) -> IResult<Input, Group> {
         TokenTree::Group(group) => Some(group.clone()),
         _ => None,
     }) {
-        Some(group) => Ok((&i[1..], group)),
+        Some(group) => Ok((Input(&i.0[1..]), group)),
         _ => Err(nom::Err::Error(make_error(i, ErrorKind::Satisfy))),
     }
 }
@@ -200,7 +258,7 @@ fn literal(i: Input) -> IResult<Input, Literal> {
         TokenTree::Literal(lit) => Some(lit.clone()),
         _ => None,
     }) {
-        Some(lit) => Ok((&i[1..], lit)),
+        Some(lit) => Ok((Input(&i.0[1..]), lit)),
         _ => Err(nom::Err::Error(make_error(i, ErrorKind::Satisfy))),
     }
 }
@@ -210,7 +268,7 @@ fn ident(i: Input) -> IResult<Input, Ident> {
         TokenTree::Ident(ident) => Some(ident.clone()),
         _ => None,
     }) {
-        Some(ident) => Ok((&i[1..], ident)),
+        Some(ident) => Ok((Input(&i.0[1..]), ident)),
         _ => Err(nom::Err::Error(make_error(i, ErrorKind::Satisfy))),
     }
 }
@@ -234,7 +292,7 @@ fn path(i: Input) -> IResult<Input, (Span, Path)> {
 fn parse_rule(tokens: TokenStream) -> Rule {
     let i: Vec<TokenTree> = tokens.into_iter().collect();
 
-    let (i, elems) = many0(parse_rule_element).parse(&i).unwrap();
+    let (i, elems) = many0(parse_rule_element).parse(Input(&i)).unwrap();
     if !i.is_empty() {
         let rest: TokenStream = i.iter().cloned().collect();
         abort!(rest, "unable to parse the following rules: {}", rest);


### PR DESCRIPTION
Currently failed with:

```
error[E0277]: the trait bound `&[proc_macro2::TokenTree]: nom::Input` is not satisfied
   --> src/lib.rs:220:17
    |
220 |         (ident, many0((match_punct(':'), match_punct(':'), ident))),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `nom::Input` is not implemented for `&[proc_macro2::TokenTree]`
    |
    = help: the trait `nom::Input` is implemented for `&[u8]`
note: required by a bound in `many0`
   --> /Users/tison/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-8.0.0/src/multi/mod.rs:67:14
    |
63  | pub fn many0<I, F>(
    |        ----- required by a bound in this function
...
67  |   I: Clone + Input,
    |              ^^^^^ required by this bound in `many0`
```